### PR TITLE
分组合并支持，合并路径指定支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 
 基于FIS的csssprites，对css文件,以及html文件css片段进行csssprites处理。支持`repeat-x`, `repeat-y`, `background-position` 和 `background-size`
 
+### 新特性
+支持图片分组合并、合并路径指定
+
 ### 使用
 
 **FIS 内置**
@@ -83,9 +86,13 @@
         //图之间的边距
         margin: 10,
         //使用矩阵排列方式，默认为线性`linear`
-        layout: 'matrix'
+        layout: 'matrix',
+        //合并图片存到/img/
+        to: '/img'
     });
     ```
+
+> `to` 参数可以为相对路径（相对当前css路径）、绝对路径（项目根路径）
 
 *以上设置可以按照需求任意组合*
 
@@ -108,7 +115,13 @@
         <td>?__sprite</td>
         <td>标识图片要做合并</td>
     </tr>
+    <tr>
+        <td>?__sprite=group</td>
+        <td>标识图片合并到"group_(x|y|z).png"</td>
+    </tr>
 </table>
+
+> `group`只支持“字母、数字、-、_”
 
 支持图片的background-position：有的情况下引用的图片已经是合并了几个小图的图片，通过`background-position`来显示每个小图，这种情况也是支持的。
 

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ try {
     imgGen = require('./libs/image.js');
 } catch (e) {
     fis.log.warning('csssprites does not support your node ' + process.version +
-        ', report it to https://github.com/xiangshouding/fis-spriter-csssprites/issues');
+        ', report it to https://github.com/fex-team/fis-spriter-csssprites/issues');
 }
 
 module.exports = function(ret, conf, settings, opt) {
@@ -65,7 +65,7 @@ function _process(content, file, index, ret, settings, opt){
     });
     var res = cssParser(content, images);
     var content = res.content;
-    if (res.map && res.map.length > 0) {
+    if (res.map) {
         var css = imgGen(file, index, res.map, images, ret, settings, opt);
         content = content + css;
     }

--- a/libs/css/rules.js
+++ b/libs/css/rules.js
@@ -14,7 +14,7 @@ var Rules = Object.derive(function (id, css) {
         , __support_position_re = /(0|[+-]?(?:\d*\.|)\d+px|left|right)\s+(0|[+-]?(?:\d*\.|)\d+px|top)/i
         , __support_size_re = /(\d+px)\s*(\d+px)/i //只支持px
         , __repeat_re = /\brepeat-(x|y)/i
-        , __sprites_re = /[?&]__sprite/i
+        , __sprites_re = /([?&])__sprite=?([a-z0-9_-]+)?(&)?/i  // 支持分组合并，多参数
         , __sprites_hook_ld = '<<<'
         , __sprites_hook_rd = '>>>';
     //selectors
@@ -27,6 +27,8 @@ var Rules = Object.derive(function (id, css) {
     self._position = [0, 0];
     //image has __sprite query ?
     self._is_sprites = false;
+    //group
+    self._group = '';
     //x,y,z
     self._direct = 'z';
     //left or right
@@ -64,7 +66,20 @@ var Rules = Object.derive(function (id, css) {
                 if (res && res[1]) {
                     info = _.stringQuote(res[1]);
                     info = _.query(info.rest);
-                    self.image = info.origin.replace(__sprites_re, '');
+                    // 图片分组合并支持
+                    self.image = info.origin.replace(__sprites_re, function (value, first, group, last) {
+                        self._group = group ? group : '__default__';
+                        if (first === '?') {
+                            if (last === '&') {
+                                return first;
+                            }else{
+                                return '';
+                            }
+                        } else {
+                            return last ? last : '';
+                        }
+                    });
+
                     if (info.query && __sprites_re.test(info.query)) {
                         self._is_sprites = true;
                     }
@@ -140,6 +155,9 @@ var Rules = Object.derive(function (id, css) {
     },
     getType: function() {
         return this._type;
+    },
+    getGroup: function() {
+        return this._group;
     },
     getDirect: function() {
         return this._direct;

--- a/libs/cssParser.js
+++ b/libs/cssParser.js
@@ -7,14 +7,19 @@
 
 var Rules = require('./css/rules.js');
 module.exports = function (content, images) {
-    var _arr_css = []
+    var _file_map = {}
         , _content;
     var reg = /(?:\/\*[\s\S]*?(?:\*\/|$))|([^\{\}\/]*)\{([^\{\}]*)\}/gi;
     _content = content.replace(reg, function(m, selector, css) {
         if (css) {
-            var rules = Rules.wrap(selector.trim(), css.trim());
+            var rules = Rules.wrap(selector.trim(), css.trim()),
+                group = rules.getGroup();
             if (rules.isSprites() && images.hasOwnProperty(rules.getImageUrl())) {
-                _arr_css.push(rules);
+                if(_file_map[group]) {
+                    _file_map[group].push(rules);
+                }else {
+                    _file_map[group] = [rules];
+                }
                 css = rules.getCss();
             }
             return selector + '{' + css + '}';
@@ -23,6 +28,6 @@ module.exports = function (content, images) {
     });
     return {
         content: _content,
-        map: _arr_css
+        map: _file_map
     };
 };

--- a/libs/image.js
+++ b/libs/image.js
@@ -19,7 +19,8 @@ function Generator(file, index, list, images, ret, settings, opt) {
         'width_limit': 10240,
         'height_limit': 10240,
         'layout': 'linear',
-        'ie_bug_fix': true
+        'ie_bug_fix': true,
+        'to': ''        // 支持合并路径指定
     };
 
 
@@ -50,56 +51,62 @@ function Generator(file, index, list, images, ret, settings, opt) {
     this.images = images;
     this.index = index;
 
-    var list_ = {};
-    var scales = {};
+    this.create = function() {
+        var list_ = {};
+        var scales = {};
 
-    function getImage(release) {
-        if (that.images.hasOwnProperty(release)) {
-            return that.images[release];
-        }
-        return false;
-    }
-
-    function insertToObject(o, key, elm) {
-        if (o[key]) {
-            o[key].push(elm);
-        } else {
-            o[key] = [elm];
-        }
-    }
-
-    fis.util.map(list, function (k, bg) {
-        var image_ = Image(getImage(bg.getImageUrl()).getContent());
-        var direct = bg.getDirect();
-
-        bg.image_ = image_;
-
-        var scale_ = bg.size[0] / image_.size().width;
-
-        if (bg.size[0] != -1 && scale_ != settings.scale) {
-            scale_ = '' + scale_;
-            //不支持x, y
-            if (direct === 'z') {
-                if (scales[scale_]) {
-                    insertToObject(scales[scale_], direct, bg);
-                } else {
-                    scales[scale_] = {};
-                    insertToObject(scales[scale_], direct, bg);
-                }
+        function getImage(release) {
+            if (that.images.hasOwnProperty(release)) {
+                return that.images[release];
             }
-        } else {
-            insertToObject(list_, direct, bg);
+            return false;
         }
-    });
 
-    this.fill(list_['x'], 'x');
-    this.fill(list_['y'], 'y');
-    this.zFill(list_['z'], settings.scale);
+        function insertToObject(o, key, elm) {
+            if (o[key]) {
+                o[key].push(elm);
+            } else {
+                o[key] = [elm];
+            }
+        }
 
-    //background-size
-    fis.util.map(scales, function (s, l) {
-        s = parseFloat(s);
-        that.zFill(l['z'], s);
+        fis.util.map(list, function (k, bg) {
+            var image_ = Image(getImage(bg.getImageUrl()).getContent());
+            var direct = bg.getDirect();
+
+            bg.image_ = image_;
+
+            var scale_ = bg.size[0] / image_.size().width;
+
+            if (bg.size[0] != -1 && scale_ != settings.scale) {
+                scale_ = '' + scale_;
+                //不支持x, y
+                if (direct === 'z') {
+                    if (scales[scale_]) {
+                        insertToObject(scales[scale_], direct, bg);
+                    } else {
+                        scales[scale_] = {};
+                        insertToObject(scales[scale_], direct, bg);
+                    }
+                }
+            } else {
+                insertToObject(list_, direct, bg);
+            }
+        });
+
+        this.fill(group, list_['x'], 'x');
+        this.fill(group, list_['y'], 'y');
+        this.zFill(group, list_['z'], settings.scale);
+
+        //background-size
+        fis.util.map(scales, function (s, l) {
+            s = parseFloat(s);
+            that.zFill(group, l['z'], s);
+        });
+    };
+
+    fis.util.map(list, function (group, glist) {
+        that.create(group, glist);
     });
 }
 
@@ -112,7 +119,7 @@ Generator.prototype = {
         }
         return false;
     },
-    after: function (image, arr_selector, direct, scale) {
+    after: function (group, image, arr_selector, direct, scale) {
         var ext = '_' + direct + '.png';
         var size = image.size();
         if (this.index) {
@@ -123,11 +130,18 @@ Generator.prototype = {
             ext = '_' + scale + ext;
         }
 
-        var image_file = fis.file.wrap(this.file.realpathNoExt + ext);
+        ext = (group=='__default__' ? '' : '_'+group) + ext;
+
+        // 支持合并路径指定
+        var root = fis.project.getProjectPath(),
+        	to_path = root + fis.util((this.settings.to.substr(0,1)=='/' ? '/' : this.file.subdirname) +'/'+this.settings.to +'/'+ this.file.filename + ext),
+        	pkg_path = to_path.substring(root.length);
+
+        var image_file = fis.file.wrap(to_path);
         image_file.setContent(image.encode('png'));
         fis.compile(image_file);
-        this.ret.pkg[this.file.subpathNoExt + ext] = image_file;
-
+        this.ret.pkg[pkg_path] = image_file;
+        
         function unique(arr) {
             var map = {};
             return arr.filter(function(item){
@@ -162,7 +176,7 @@ Generator.prototype = {
 
     },
     z_pack: require('./pack.js'),
-    fill: function(list, direct) {
+    fill: function(group, list, direct) {
         if (!list || list.length == 0) {
             return;
         }
@@ -244,9 +258,9 @@ Generator.prototype = {
             }
         }
 
-        this.after(image, cls, direct);
+        this.after(group, image, cls, direct);
     },
-    zFill: function(list, scale) {
+    zFill: function(group, list, scale) {
         if (!list || list.length == 0) {
             return;
         }
@@ -386,6 +400,6 @@ Generator.prototype = {
                 y += current.h;
             }
         }
-        this.after(image, cls, 'z', scale);
+        this.after(group, image, cls, 'z', scale);
     }
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fis-spriter-csssprites",
-  "version": "0.3.5",
-  "description": "基于fis的csssprite，支持repeat-x，repeat-x，background-position",
+  "version": "0.3.6",
+  "description": "基于fis的csssprite，支持分组合并图片，合并路径指定，支持repeat-x，repeat-x，background-position",
   "main": "index.js",
   "directories": {
     "test": "test"
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/fis-dev/fis-spriter-csssprites.git"
+    "url": "https://github.com/fex-team/fis-spriter-csssprites.git"
   },
   "dependencies": {
     "images": "2.1.10"
@@ -30,6 +30,6 @@
   "author": "xiangshouding <xiangshouding@baidu.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/fis-dev/fis-spriter-csssprites/issues"
+    "url": "https://github.com/fex-team/fis-spriter-csssprites/issues"
   }
 }


### PR DESCRIPTION
不带参数?__sprite，跟原来一样，以css文件名命名
带分组参数?__sprite=group，图片合并为group_(x|y|z).png

// 合并目录指定
fis.config.set('settings.spriter.csssprites', {
    //合并图片存到/img/，支持相对目录
    to: '/img'
});